### PR TITLE
Add UbuCon Asia 2025 to events page

### DIFF
--- a/events.json
+++ b/events.json
@@ -1,4 +1,11 @@
-[
+[    {
+        "coordinates": [27.693269, 85.321012],
+        "address": "St. Xavier's College, Maitighar, Kathmandu, Nepal",
+        "event": "UbuCon Asia 2025",
+        "date": "2025-09-15",
+        "url": "https://2025.ubucon.asia/"
+    },
+
     {
         "coordinates": [37.572607, 126.990822],
         "address": "50, Jongno-1-gil, Jongno-gu, Seoul, Republic of Korea",


### PR DESCRIPTION
This PR adds the details for **UbuCon Asia 2025** to the events section of the website.  

#### Event Details:  
- **Event Name**: UbuCon Asia 2025  
- **Date**: September 15, 2025  
- **Location**: St. Xavier's College, Maitighar, Kathmandu, Nepal  
- **Coordinates**: [27.693269, 85.321012]  
- **Event URL**: [https://2025.ubucon.asia/](https://2025.ubucon.asia/)  
