### PR TITLE
Update UbuCon Asia 2025 date to August 30, 2025

### DIFF
--- a/events.json
+++ b/events.json
@@ -2,7 +2,7 @@
         "coordinates": [27.693269, 85.321012],
         "address": "St. Xavier's College, Maitighar, Kathmandu, Nepal",
         "event": "UbuCon Asia 2025",
-        "date": "2025-09-15",
+        "date": "2025-08-30",
         "url": "https://2025.ubucon.asia/"
     },
 

--- a/events.json
+++ b/events.json
@@ -34,7 +34,7 @@
         "date": "2024-08-16",
         "url": "https://ubuconla.org/"
     },
-        {
+    {
         "coordinates": [3.1531161, 101.7100402],
         "address": "Kuala Lumpur Convention Centre, Kuala Lumpur, Malaysia",
         "event": "Mini UbuCon Malaysia 2024",


### PR DESCRIPTION
This PR updates the event date for **UbuCon Asia 2025** to **August 30, 2025**.

#### Updated Event Details:
- **Event Name**: UbuCon Asia 2025  
- **Date**: August 30, 2025  
- **Location**: St. Xavier's College, Maitighar, Kathmandu, Nepal  
- **Coordinates**: [27.693269, 85.321012]  
- **Event URL**: [https://2025.ubucon.asia/](https://2025.ubucon.asia/)  
