### PR TITLE
refactor: update name and affiliation

### DIFF
--- a/scale/index.html
+++ b/scale/index.html
@@ -147,8 +147,8 @@
           <div class="p-card__image">
             <img src="speakers/jason.jpg" width="150px" />
           </div>
-            <h3 class="p-heading--5">Jason Nucciarone</h3>
-          <p>Canonical</p>
+            <h3 class="p-heading--5">Jason C. Nucciarone</h3>
+          <p>Ubuntu High-Performance Computing</p>
         </div>
       </div>
       <div class="col-2 p-card">
@@ -157,7 +157,7 @@
             <img src="speakers/aaron.jpg" width="150px" />
           </div>
             <h3 class="p-heading--5">Aaron Prisk</h3>
-          <p>Canonical</p>
+          <p>Canonical Community Team</p>
         </div>
       </div>
       <div class="col-2 p-card">


### PR DESCRIPTION
This PR updates my affiliation for UbuCon @ SCaLE 22x from "Canonical" to "Ubuntu High-Performance Computing." That way it's extra cool when I talk about Charmed HPC.

I also updated @aaronprisk affiliation to Canonical Community Team since it's cool to have an official community representative at the event. Might catch the heat, but they gotta know that you're a big dog :dog2: 