### PR TITLE
fix: remove whitespace below footer

### DIFF
--- a/scale/index.html
+++ b/scale/index.html
@@ -1,23 +1,23 @@
 <!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <html lang="en">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta name="description" content="UbuCon @ SCaLE 22x">
-        <meta name="keywords" content="ubucon,ubuntu">
-        <meta name="robots" content="index, follow">
-        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-        <meta name="language" content="English">
-        <meta property="og:title" content="UbuCon @ SCaLE 22x" />
-        <meta property="og:description" content="The biggest open source community at the biggest open source event in North America!" />
-        <meta property="og:image" content="https://ubucon.org/scale/img/ubucon-banner.png" />
-        <title>UbuCon @ SCaLE 22x</title>
-        <link rel="shortcut icon" href="/img/favicon.ico" type="image/x-icon">
-        <link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-4.8.0.min.css" />
-        <script src="main.js"></script>
-        <link rel="stylesheet" href="main.css" />
-    </head>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="UbuCon @ SCaLE 22x">
+  <meta name="keywords" content="ubucon,ubuntu">
+  <meta name="robots" content="index, follow">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta name="language" content="English">
+  <meta property="og:title" content="UbuCon @ SCaLE 22x" />
+  <meta property="og:description" content="The biggest open source community at the biggest open source event in North America!" />
+  <meta property="og:image" content="https://ubucon.org/scale/img/ubucon-banner.png" />
+  <title>UbuCon @ SCaLE 22x</title>
+  <link rel="shortcut icon" href="/img/favicon.ico" type="image/x-icon">
+  <link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-4.8.0.min.css" />
+  <script src="main.js"></script>
+  <link rel="stylesheet" href="main.css" />
+</head>
+<body>
   <header id="navigation" class="p-navigation is-dark">
     <div class="p-navigation__row--25-75">
       <div class="p-navigation__banner">
@@ -48,7 +48,6 @@
       </nav>
     </div>
   </header>
-
   <div class="p-section--hero">
     <div class="row">
       <div class="col-8">
@@ -59,7 +58,7 @@
           The biggest open source community at the biggest open source event in North America!
         </p>
         <p>
-          UbuCon is back in Pasadena at the SCaLE expo for a special one day event featuring the latest innovations happening across the Ubuntu ecosystem!
+          UbuCon is back in Pasadena at the SCaLE expo for a special one-day event featuring the latest innovations happening across the Ubuntu ecosystem!
         </p>
         <p>Whether you're into the <strong>Ubuntu Desktop, Software Development, AI/ML, Security, Virtualization, HPC, or something else</strong>; there will be something here for you.</p>
         <p>
@@ -73,118 +72,117 @@
     </div>
   </div>
 
-  <section class="p-section">
-    <div class="row">
-      <hr class="p-rule" />
-      <h2>Featured speakers</h2>
-      <div class="col-2 p-card">
-        <div class="p-card__content">
-          <div class="p-card__image">
-            <img src="speakers/noah.jpg" width="150px" />
-          </div>
-            <h3 class="p-heading--5">Noah Chelliah</h3>
-          <p>AskNoah Show | Altispeed Technologies</p>
+  <div class="row">
+    <hr class="p-rule" />
+    <h2>Featured speakers</h2>
+    <div class="col-2 p-card">
+      <div class="p-card__content">
+        <div class="p-card__image">
+          <img src="speakers/noah.jpg" width="150px" />
         </div>
-      </div>
-      <div class="col-2 p-card">
-        <div class="p-card__content">
-          <div class="p-card__image">
-            <img src="speakers/ken.jpg" width="150px" />
-          </div>
-            <h3 class="p-heading--5">Ken VanDine</h3>
-          <p>Canonical</p>
-        </div>
-      </div>
-      <div class="col-2 p-card">
-        <div class="p-card__content">
-          <div class="p-card__image">
-            <img src="speakers/rajan.jpg" width="150px" />
-          </div>
-            <h3 class="p-heading--5">Rajan Patel</h3>
-          <p>Canonical</p>
-        </div>
-      </div>
-      <div class="col-2 p-card">
-        <div class="p-card__content">
-          <div class="p-card__image">
-            <img src="speakers/nathan.jpg" width="150px" />
-          </div>
-            <h3 class="p-heading--5">Nathan Haines</h3>
-          <p>Ubuntu Community Council</p>
-        </div>
-      </div>
-      <div class="col-2 p-card">
-        <div class="p-card__content">
-          <div class="p-card__image">
-            <img src="speakers/alastair.jpg" width="150px" />
-          </div>
-            <h3 class="p-heading--5">Alastair Flynn</h3>
-          <p>Canonical</p>
-        </div>
-      </div>
-      <div class="col-2 p-card">
-        <div class="p-card__content">
-          <div class="p-card__image">
-            <img src="speakers/miona.jpg" width="150px" />
-          </div>
-            <h3 class="p-heading--5">Miona Aleksic</h3>
-          <p>Canonical</p>
-        </div>
+          <h3 class="p-heading--5">Noah Chelliah</h3>
+        <p>AskNoah Show | Altispeed Technologies</p>
       </div>
     </div>
-    <div class="row">
-      <div class="col-2 p-card">
-        <div class="p-card__content">
-          <div class="p-card__image">
-            <img src="speakers/richard.jpg" width="150px" />
-          </div>
-            <h3 class="p-heading--5">Richard Gaskin</h3>
-          <p>Ubuntu California</p>
+    <div class="col-2 p-card">
+      <div class="p-card__content">
+        <div class="p-card__image">
+          <img src="speakers/ken.jpg" width="150px" />
         </div>
-      </div>
-      <div class="col-2 p-card">
-        <div class="p-card__content">
-          <div class="p-card__image">
-            <img src="speakers/jason.jpg" width="150px" />
-          </div>
-            <h3 class="p-heading--5">Jason C. Nucciarone</h3>
-          <p>Ubuntu High-Performance Computing</p>
-        </div>
-      </div>
-      <div class="col-2 p-card">
-        <div class="p-card__content">
-          <div class="p-card__image">
-            <img src="speakers/aaron.jpg" width="150px" />
-          </div>
-            <h3 class="p-heading--5">Aaron Prisk</h3>
-          <p>Canonical Community Team</p>
-        </div>
-      </div>
-      <div class="col-2 p-card">
-        <div class="p-card__content">
-          <div class="p-card__image">
-            <img src="speakers/kadin.jpg" width="150px" />
-          </div>
-            <h3 class="p-heading--5">Kadin Sayani</h3>
-          <p>Canonical</p>
-        </div>
-      </div>
-      <div class="col-2 p-card">
-        <div class="p-card__content">
-          <div class="p-card__image">
-             <img src="speakers/eric.jpg" width="150px" />
-          </div>
-            <h3 class="p-heading--5">Eric Gelinas</h3>
-          <p>Canonical</p>
-        </div>
+          <h3 class="p-heading--5">Ken VanDine</h3>
+        <p>Canonical</p>
       </div>
     </div>
-    <div class="row">
-      <div class="col-12">
-        <a href="schedule.html"
-           class="p-button">Full schedule</a>
+    <div class="col-2 p-card">
+      <div class="p-card__content">
+        <div class="p-card__image">
+          <img src="speakers/rajan.jpg" width="150px" />
+        </div>
+          <h3 class="p-heading--5">Rajan Patel</h3>
+        <p>Canonical</p>
       </div>
     </div>
+    <div class="col-2 p-card">
+      <div class="p-card__content">
+        <div class="p-card__image">
+          <img src="speakers/nathan.jpg" width="150px" />
+        </div>
+          <h3 class="p-heading--5">Nathan Haines</h3>
+        <p>Ubuntu Community Council</p>
+      </div>
+    </div>
+    <div class="col-2 p-card">
+      <div class="p-card__content">
+        <div class="p-card__image">
+          <img src="speakers/alastair.jpg" width="150px" />
+        </div>
+          <h3 class="p-heading--5">Alastair Flynn</h3>
+        <p>Canonical</p>
+      </div>
+    </div>
+    <div class="col-2 p-card">
+      <div class="p-card__content">
+        <div class="p-card__image">
+          <img src="speakers/miona.jpg" width="150px" />
+        </div>
+          <h3 class="p-heading--5">Miona Aleksic</h3>
+        <p>Canonical</p>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-2 p-card">
+      <div class="p-card__content">
+        <div class="p-card__image">
+          <img src="speakers/richard.jpg" width="150px" />
+        </div>
+          <h3 class="p-heading--5">Richard Gaskin</h3>
+        <p>Ubuntu California</p>
+      </div>
+    </div>
+    <div class="col-2 p-card">
+      <div class="p-card__content">
+        <div class="p-card__image">
+          <img src="speakers/jason.jpg" width="150px" />
+        </div>
+          <h3 class="p-heading--5">Jason C. Nucciarone</h3>
+        <p>Ubuntu High-Performance Computing</p>
+      </div>
+    </div>
+    <div class="col-2 p-card">
+      <div class="p-card__content">
+        <div class="p-card__image">
+          <img src="speakers/aaron.jpg" width="150px" />
+        </div>
+          <h3 class="p-heading--5">Aaron Prisk</h3>
+        <p>Canonical Community Team</p>
+      </div>
+    </div>
+    <div class="col-2 p-card">
+      <div class="p-card__content">
+        <div class="p-card__image">
+          <img src="speakers/kadin.jpg" width="150px" />
+        </div>
+          <h3 class="p-heading--5">Kadin Sayani</h3>
+        <p>Canonical</p>
+      </div>
+    </div>
+    <div class="col-2 p-card">
+      <div class="p-card__content">
+        <div class="p-card__image">
+           <img src="speakers/eric.jpg" width="150px" />
+        </div>
+          <h3 class="p-heading--5">Eric Gelinas</h3>
+        <p>Canonical</p>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <a href="schedule.html"
+         class="p-button">Full schedule</a>
+    </div>
+  </div>
 
   <section class="p-section" id="attend">
     <div class="row--50-50">
@@ -215,30 +213,32 @@
       <div class="p-logo-section has-misaligned-images">
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
-           <img src="img/canonical.svg" width="200px" />
+            <img src="img/canonical.svg" width="200px" />
           </div>
         </div>
       </div>
     </div>
   </section>
-        <footer class="p-strip--dark l-docs__subgrid">
-            <div class="l-docs__sidebar">
-                <p style="padding-left: 1.5rem"></p>
-            </div>
-            <div class="l-docs__main">
-                <nav class="row" aria-label="Footer">
-                    <div class="has-cookie">
-                        <p><a class="is-dark" href="https://ubuntu.com/">Ubuntu</a> and <a class="is-dark" href="https://canonical.com/">Canonical</a> are registered trademarks of Canonical Ltd.</p>
-                        <ul class="p-inline-list--middot">
-                            <li class="p-inline-list__item">
-                                <a class="is-dark" href="https://ubuntu.com/legal"><small>Legal information</small></a>
-                            </li>
-                            <li class="p-inline-list__item">
-                                <a class="is-dark" href="https://github.com/aaronprisk/ubucon.org"><small>Report a bug on this site</small></a>
-                            </li>
-                        </ul>
-                        <span class="u-off-screen"><a href="#">Go to the top of the page</a></span>
-                    </div>
-                </nav>
-            </div>
-        </footer>
+  <footer class="p-strip--dark l-docs__subgrid">
+    <div class="l-docs__sidebar">
+        <p style="padding-left: 1.5rem"></p>
+    </div>
+    <div class="l-docs__main">
+      <nav class="row" aria-label="Footer">
+        <div class="has-cookie">
+          <p><a class="is-dark" href="https://ubuntu.com/">Ubuntu</a> and <a class="is-dark" href="https://canonical.com/">Canonical</a> are registered trademarks of Canonical Ltd.</p>
+          <ul class="p-inline-list--middot">
+            <li class="p-inline-list__item">
+                <a class="is-dark" href="https://ubuntu.com/legal"><small>Legal information</small></a>
+            </li>
+            <li class="p-inline-list__item">
+                <a class="is-dark" href="https://github.com/aaronprisk/ubucon.org"><small>Report a bug on this site</small></a>
+            </li>
+          </ul>
+          <span class="u-off-screen"><a href="#">Go to the top of the page</a></span>
+        </div>
+      </nav>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
Removed the whitespace below the footer on the main page for "UbuCon @ SCaLE 22x." It was bugging me because it's a common issue I run into when making my own sites.

Peep new look :point_down: 

![image](https://github.com/user-attachments/assets/41fd8f38-80c9-4e74-8cf3-1b5359e61dc5)

Others changes:

* Add missing `<body>` tag.
* Properly close `<html>` tag.
* Make indentation consistent throughout document.