### PR TITLE
Change date for UbuCon Korea 2025

### DIFF
--- a/events.json
+++ b/events.json
@@ -10,7 +10,7 @@
         "coordinates": [37.574686, 126.979017],
         "address": "Microsoft Korea, 50 Jong-ro 1-gil, Jongno-gu, Seoul",
         "event": "UbuCon Korea 2025",
-        "date": "2025-08-09",
+        "date": "2025-08-10",
         "url": "https://2025.ubuntu-kr.org/"
     },
 


### PR DESCRIPTION
Aug 9 -> Aug 10

Source: https://discourse.ubuntu-kr.org/t/ubucon-korea-2025-8-10/50000?u=sukso96100