### PR TITLE
Add UbuCon Korea 2026 Info

### DIFF
--- a/events.json
+++ b/events.json
@@ -117,7 +117,7 @@
         "coordinates": [37.574686, 126.979017],
         "address": "Microsoft Korea, 50 Jong-ro 1-gil, Jongno-gu, Seoul",
         "event": "UbuCon Korea 2026",
-        "date": "2025-08-29",
+        "date": "2026-08-29",
         "url": "https://2026.ubuntu-kr.org/"
     }
 ]

--- a/events.json
+++ b/events.json
@@ -112,5 +112,12 @@
         "event": "UbuCon Cameroon 2026 @ PyCon Cameroon",
         "date": "2026-09-17",
         "url": "https://cm.pycon.org/ubucon"
+    },
+    {
+        "coordinates": [37.574686, 126.979017],
+        "address": "Microsoft Korea, 50 Jong-ro 1-gil, Jongno-gu, Seoul",
+        "event": "UbuCon Korea 2026",
+        "date": "2025-08-29",
+        "url": "https://2026.ubuntu-kr.org/"
     }
 ]


### PR DESCRIPTION
As UbuCon Korea 2026 website opened now, update UbuCon Korea 2026 to https://ubucon.org .

Thank you for maintaining the website to find other UbuCons worldwide.